### PR TITLE
Replace angular building blocks references with entry.

### DIFF
--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-edit-generated.component.ts.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-edit-generated.component.ts.txt
@@ -11,7 +11,7 @@ import { Component, EventEmitter, Inject, Input, LOCALE_ID, OnInit, OnDestroy, O
 import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { IFormMock } from 'src/app/api/api-reference';
-import { IFieldExpressionDictionary, IFieldPropertyExpressionDictionary, SelectConfiguration, ENIGMATRY_FIELD_TYPE_RESOLVER, FieldTypeResolver, sortOptions } from '@enigmatry/angular-building-blocks/form';
+import { IFieldExpressionDictionary, IFieldPropertyExpressionDictionary, SelectConfiguration, ENTRY_FIELD_TYPE_RESOLVER, FieldTypeResolver, sortOptions } from '@enigmatry/entry-form';
 import { BehaviorSubject, of, Subject, Subscription } from 'rxjs';
 import { map, throttleTime } from 'rxjs/operators';
 
@@ -71,7 +71,7 @@ export class MockEditGeneratedComponent implements OnInit, OnDestroy {
 
   constructor(
     @Inject(LOCALE_ID) private _localeId: string,
-    @Optional() @Inject(ENIGMATRY_FIELD_TYPE_RESOLVER) private _fieldTypeResolver: FieldTypeResolver) { }
+    @Optional() @Inject(ENTRY_FIELD_TYPE_RESOLVER) private _fieldTypeResolver: FieldTypeResolver) { }
 
   ngOnInit(): void {
     this.fields = this.initializeFields();
@@ -99,7 +99,7 @@ export class MockEditGeneratedComponent implements OnInit, OnDestroy {
         {
         key: 'resetFormBtn',
         type: this.resolveFieldType('button', false),
-        className: 'entry-reset-form-btn-field entry-button primary-button',
+className: 'entry-reset-form-btn-field entry-button primary-button',
         hideExpression: this.fieldsHideExpressions?.resetFormBtn ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.resetFormBtn ? this.fieldsDisableExpressions.resetFormBtn(model) : false)),
@@ -117,7 +117,7 @@ export class MockEditGeneratedComponent implements OnInit, OnDestroy {
         },
         {
         type: this.resolveFieldType('group-type', false),
-        fieldGroupClassName: 'entry-field-group',
+fieldGroupClassName: 'entry-field-group',
                 wrappers: ['group-wrapper'],
         templateOptions: {
         label: $localize `:@@test.mock-edit.group-name.label:Group name`,
@@ -129,7 +129,7 @@ export class MockEditGeneratedComponent implements OnInit, OnDestroy {
         {
         key: 'name',
         type: this.resolveFieldType('input', false),
-        className: 'entry-name-field entry-input',
+className: 'entry-name-field entry-input',
         hideExpression: this.fieldsHideExpressions?.name ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.name ? this.fieldsDisableExpressions.name(model) : false)),
@@ -163,7 +163,7 @@ modelOptions: { updateOn: 'blur' },
         {
         key: 'description',
         type: this.resolveFieldType('textarea', false),
-        className: 'entry-description-field entry-textarea',
+className: 'entry-description-field entry-textarea',
         hideExpression: this.fieldsHideExpressions?.description ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.description ? this.fieldsDisableExpressions.description(model) : false)),
@@ -188,7 +188,7 @@ modelOptions: { updateOn: 'blur' },
         {
         key: 'date',
         type: this.resolveFieldType('datepicker', true),
-        className: 'entry-date-field entry-datepicker',
+className: 'entry-date-field entry-datepicker',
         hideExpression: this.fieldsHideExpressions?.date ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.date ? this.fieldsDisableExpressions.date(model) : true)),
@@ -208,7 +208,7 @@ modelOptions: { updateOn: 'blur' },
         {
         key: 'money',
         type: this.resolveFieldType('input', false),
-        className: 'entry-money-field entry-input',
+className: 'entry-money-field entry-input',
         hideExpression: this.fieldsHideExpressions?.money ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.money ? this.fieldsDisableExpressions.money(model) : false)),
@@ -229,7 +229,7 @@ max: 999.99 - 0.1,
         {
         key: 'amount',
         type: this.resolveFieldType('input', false),
-        className: 'entry-amount-field entry-input',
+className: 'entry-amount-field entry-input',
         hideExpression: this.fieldsHideExpressions?.amount ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.amount ? this.fieldsDisableExpressions.amount(model) : false)),
@@ -258,7 +258,7 @@ max: (err, field) => $localize `:@@test.mock-edit.amount.max:CUSTOM_VALIDATION_M
         {
         key: 'formStatus',
         type: this.resolveFieldType('select', false),
-        className: 'entry-form-status-field entry-select',
+className: 'entry-form-status-field entry-select',
         hideExpression: this.fieldsHideExpressions?.formStatus ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.formStatus ? this.fieldsDisableExpressions.formStatus(model) : false)),
@@ -279,7 +279,7 @@ max: (err, field) => $localize `:@@test.mock-edit.amount.max:CUSTOM_VALIDATION_M
         {
         key: 'mockRadio',
         type: this.resolveFieldType('radio', false),
-        className: 'entry-mock-radio-field entry-radio',
+className: 'entry-mock-radio-field entry-radio',
         hideExpression: this.fieldsHideExpressions?.mockRadio ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.mockRadio ? this.fieldsDisableExpressions.mockRadio(model) : false)),
@@ -300,7 +300,7 @@ max: (err, field) => $localize `:@@test.mock-edit.amount.max:CUSTOM_VALIDATION_M
         {
         key: 'mockMultiCheckbox',
         type: this.resolveFieldType('multicheckbox', false),
-        className: 'entry-mock-multi-checkbox-field entry-multicheckbox',
+className: 'entry-mock-multi-checkbox-field entry-multicheckbox',
         hideExpression: this.fieldsHideExpressions?.mockMultiCheckbox ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.mockMultiCheckbox ? this.fieldsDisableExpressions.mockMultiCheckbox(model) : false)),
@@ -311,7 +311,7 @@ max: (err, field) => $localize `:@@test.mock-edit.amount.max:CUSTOM_VALIDATION_M
         label: $localize `:@@test.mock-edit.mock-multi-checkbox.label:MultiCheckbox`,
         placeholder: $localize `:@@test.mock-edit.mock-multi-checkbox.placeholder:MultiCheckbox`,
         description: '',
-        type:'array',
+            type: 'array',
             options: of(this.mockMultiCheckboxOptions).pipe(map(opts => sortOptions(opts, this.mockMultiCheckboxOptionsConfiguration.valueProperty, this.mockMultiCheckboxOptionsConfiguration.sortProperty, this._localeId))),
             valueProp: this.mockMultiCheckboxOptionsConfiguration.valueProperty,
             labelProp: this.mockMultiCheckboxOptionsConfiguration.labelProperty,
@@ -322,7 +322,7 @@ max: (err, field) => $localize `:@@test.mock-edit.amount.max:CUSTOM_VALIDATION_M
         {
         key: 'categoryId',
         type: this.resolveFieldType('select', false),
-        className: 'entry-category-id-field entry-select',
+className: 'entry-category-id-field entry-select',
         hideExpression: this.fieldsHideExpressions?.categoryId ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.categoryId ? this.fieldsDisableExpressions.categoryId(model) : false)),
@@ -344,7 +344,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         {
         key: 'types',
         type: this.resolveFieldType('select', false),
-        className: 'entry-types-field entry-select',
+className: 'entry-types-field entry-select',
         hideExpression: this.fieldsHideExpressions?.types ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.types ? this.fieldsDisableExpressions.types(model) : false)),
@@ -363,11 +363,11 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         hidden: !true,
             typeFormatDef: undefined
         },
-        },        
+        },
         {
         key: 'password',
         type: this.resolveFieldType('input', false),
-        className: 'entry-password-field entry-input',
+className: 'entry-password-field entry-input',
         hideExpression: this.fieldsHideExpressions?.password ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.password ? this.fieldsDisableExpressions.password(model) : false)),
@@ -378,7 +378,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         label: $localize `:@@test.mock-edit.password.label:Password`,
         placeholder: $localize `:@@test.mock-edit.password.placeholder:Password`,
         description: '',
-        type: 'password',
+            type: 'password',
         hidden: !true,
             typeFormatDef: undefined
         },
@@ -386,7 +386,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         {
         key: 'addresses',
         type: this.resolveFieldType('array-field', false),
-        className: 'entry-addresses-field entry-array-field',
+className: 'entry-addresses-field entry-array-field',
         hideExpression: this.fieldsHideExpressions?.addresses ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.addresses ? this.fieldsDisableExpressions.addresses(model) : false)),
@@ -404,7 +404,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
             fieldArray:
         {
         type: this.resolveFieldType('', false),
-        fieldGroupClassName: 'entry-field-group',
+fieldGroupClassName: 'entry-field-group',
                 wrappers: ['group-wrapper'],
         templateOptions: {
         label: '',
@@ -417,7 +417,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         {
         key: 'city',
         type: this.resolveFieldType('input', false),
-        className: 'entry-city-field entry-input',
+className: 'entry-city-field entry-input',
         defaultValue: 'Amsterdam',
         hideExpression: this.fieldsHideExpressions?.city ?? false,
         expressionProperties: {
@@ -436,7 +436,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         {
         key: 'street',
         type: this.resolveFieldType('input', false),
-        className: 'entry-street-field entry-input',
+className: 'entry-street-field entry-input',
         hideExpression: this.fieldsHideExpressions?.street ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.street ? this.fieldsDisableExpressions.street(model) : false)),
@@ -454,7 +454,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         {
         key: 'houseNumber',
         type: this.resolveFieldType('input', false),
-        className: 'entry-house-number-field entry-input',
+className: 'entry-house-number-field entry-input',
         hideExpression: this.fieldsHideExpressions?.houseNumber ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.houseNumber ? this.fieldsDisableExpressions.houseNumber(model) : false)),
@@ -472,7 +472,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         {
         key: 'verified',
         type: this.resolveFieldType('checkbox', true),
-        className: 'entry-verified-field entry-checkbox',
+className: 'entry-verified-field entry-checkbox',
         hideExpression: this.fieldsHideExpressions?.verified ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.verified ? this.fieldsDisableExpressions.verified(model) : true)),
@@ -495,7 +495,7 @@ metadata: { entityType: 'Category', filter: 'category_name' },
         {
         key: 'email1',
         type: this.resolveFieldType('input', false),
-        className: 'entry-email1-field entry-input',
+className: 'entry-email1-field entry-input',
         hideExpression: this.fieldsHideExpressions?.email1 ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.email1 ? this.fieldsDisableExpressions.email1(model) : false)),
@@ -521,7 +521,7 @@ pattern: (err, field) => $localize `:@@test.mock-edit.email1.pattern:CUSTOM_VALI
         {
         key: 'email2',
         type: this.resolveFieldType('input', false),
-        className: 'entry-email2-field entry-input',
+className: 'entry-email2-field entry-input',
         hideExpression: this.fieldsHideExpressions?.email2 ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.email2 ? this.fieldsDisableExpressions.email2(model) : false)),

--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-list-generated.component.html.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-list-generated.component.html.txt
@@ -1,5 +1,5 @@
 
-<enigmatry-grid 
+<entry-table 
                 class="entry-mock-list-table entry-table"
                 [columns]="columns" 
                 [data]="data" 
@@ -28,7 +28,7 @@
                 (rowSelectionChange)="selectionChange.emit($event)"
                 (contextMenuItemSelected)="contextMenuItemSelected.emit($event)"
                 (rowClick)="rowClick.emit($event)">
-</enigmatry-grid>
+</entry-table>
 
 <ng-template #nameTpl let-row let-index="index" let-col="colDef">
     <custom-cell [rowData]="row" [colDef]="col"></custom-cell>

--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-list-generated.component.ts.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-list-generated.component.ts.txt
@@ -8,8 +8,7 @@
 // ------------------------------------------------------------------------------;
 /* eslint-disable */
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';
-import { CellTemplate, ColumnDef, ContextMenuItem, RowClassFormatter, RowContextMenuFormatter, RowSelectionFormatter } from '@enigmatry/angular-building-blocks/enigmatry-grid';
-import { PagedData, PageEvent, SortDirection, SortEvent } from '@enigmatry/angular-building-blocks/pagination';
+import { PagedData, SortDirection, CellTemplate, ContextMenuItem, RowContextMenuFormatter, RowClassFormatter, RowSelectionFormatter, ColumnDef, PageEvent, SortEvent } from '@enigmatry/entry-table';
 
 import { ListMockItem } from 'src/app/api/api-reference';
 

--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/test-generated.module.ts.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/test-generated.module.ts.txt
@@ -10,7 +10,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from 'src/app/shared/shared.module';
-import { EnigmatryGridModule } from '@enigmatry/angular-building-blocks/enigmatry-grid';
+import { EntryTableModule } from '@enigmatry/entry-table';
     import { FormlyModule, FORMLY_CONFIG } from '@ngx-formly/core';
     import { FormlyMaterialModule } from '@ngx-formly/material';
     import { MatAutocompleteModule } from '@angular/material/autocomplete';
@@ -26,7 +26,7 @@ import { CustomValidatorsService, customValidatorsFactory } from 'src/app/shared
     imports: [
     CommonModule,
     SharedModule,
-    EnigmatryGridModule,
+    EntryTableModule,
         MatAutocompleteModule,
         FormlyModule.forChild(
             {

--- a/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.Form.Component.cshtml
+++ b/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.Form.Component.cshtml
@@ -10,7 +10,7 @@ import { Component, EventEmitter, Inject, Input, LOCALE_ID, OnInit, OnDestroy, O
 import { FormGroup } from '@@angular/forms';
 import { FormlyFieldConfig } from '@@ngx-formly/core';
 import { I@(Model.ComponentInfo.ModelType) } from '@_options.ApiClientTsImportPath';
-import { IFieldExpressionDictionary, IFieldPropertyExpressionDictionary, SelectConfiguration, ENIGMATRY_FIELD_TYPE_RESOLVER, FieldTypeResolver, sortOptions } from '@@enigmatry/angular-building-blocks/form';
+import { IFieldExpressionDictionary, IFieldPropertyExpressionDictionary, SelectConfiguration, ENTRY_FIELD_TYPE_RESOLVER, FieldTypeResolver, sortOptions } from '@@enigmatry/entry-form';
 import { BehaviorSubject, of, Subject, Subscription } from 'rxjs';
 import { map, throttleTime } from 'rxjs/operators';
 
@@ -248,7 +248,7 @@ export class @Model.AngularComponentName() implements OnInit, OnDestroy {
 
   constructor(
     @@Inject(LOCALE_ID) private _localeId: string,
-    @@Optional() @@Inject(ENIGMATRY_FIELD_TYPE_RESOLVER) private _fieldTypeResolver: FieldTypeResolver) { }
+    @@Optional() @@Inject(ENTRY_FIELD_TYPE_RESOLVER) private _fieldTypeResolver: FieldTypeResolver) { }
 
   ngOnInit(): void {
     this.fields = this.initializeFields();

--- a/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.List.Component.cshtml
+++ b/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.List.Component.cshtml
@@ -6,8 +6,7 @@
 @model Enigmatry.Entry.CodeGeneration.Configuration.List.ListComponentModel;
 @inject CodeGeneratorOptions _options;
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@@angular/core';
-import { CellTemplate, ColumnDef, ContextMenuItem, RowClassFormatter, RowContextMenuFormatter, RowSelectionFormatter } from '@@enigmatry/angular-building-blocks/enigmatry-grid';
-import { PagedData, PageEvent, SortDirection, SortEvent } from '@@enigmatry/angular-building-blocks/pagination';
+import { PagedData, SortDirection, CellTemplate, ContextMenuItem, RowContextMenuFormatter, RowClassFormatter, RowSelectionFormatter, ColumnDef, PageEvent, SortEvent } from '@@enigmatry/entry-table';
 
 import { @(Model.ComponentInfo.ModelType) } from '@_options.ApiClientTsImportPath';
 

--- a/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.List.View.cshtml
+++ b/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.List.View.cshtml
@@ -3,7 +3,7 @@
 
 @model Enigmatry.Entry.CodeGeneration.Configuration.List.ListComponentModel;
 
-<enigmatry-grid
+<entry-table
                 @Html.ListCssClass(Model)
                 [columns]="columns"
                 [data]="data"
@@ -32,7 +32,7 @@
                 (rowSelectionChange)="selectionChange.emit($event)"
                 (contextMenuItemSelected)="contextMenuItemSelected.emit($event)"
                 (rowClick)="rowClick.emit($event)">
-</enigmatry-grid>
+</entry-table>
 
 @foreach (var column in Model.Columns.Where(column => column.HasCustomCellComponent))
 {

--- a/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.Module.cshtml
+++ b/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.Module.cshtml
@@ -8,7 +8,7 @@
 import { NgModule } from '@@angular/core';
 import { CommonModule } from '@@angular/common';
 import { SharedModule } from 'src/app/shared/shared.module';
-import { EnigmatryGridModule } from '@@enigmatry/angular-building-blocks/enigmatry-grid';
+import { EntryTableModule } from '@@enigmatry/entry-table';
 @if (Model.HasFormComponents)
 {
     @:import { FormlyModule, FORMLY_CONFIG } from '@@ngx-formly/core';
@@ -25,7 +25,7 @@ import { EnigmatryGridModule } from '@@enigmatry/angular-building-blocks/enigmat
     imports: [
     CommonModule,
     SharedModule,
-    EnigmatryGridModule,
+    EntryTableModule,
     @if (Model.HasFormComponents)
     {
         @:MatAutocompleteModule,


### PR DESCRIPTION
Replace angular building blocks references with entry:

- @enigmatry/entry-table is used instead of @enigmatry/angular-building-blocks/enigmatry-grid
- @enigmatry/entry-form is used instead of @enigmatry/angular-building-blocks/form