### PR TITLE
BP-491: Support skipping translation for I18NString when Key is empty.

### DIFF
--- a/Enigmatry.Entry.CodeGeneration.Configuration/Form/Controls/Select/SelectOption.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration/Form/Controls/Select/SelectOption.cs
@@ -1,9 +1,16 @@
-﻿namespace Enigmatry.Entry.CodeGeneration.Configuration.Form.Controls;
+﻿using System;
+
+namespace Enigmatry.Entry.CodeGeneration.Configuration.Form.Controls;
 
 public class SelectOption
 {
     public object? Value { get; }
     public I18NString DisplayName { get; }
+
+    public SelectOption(object? value, string displayName)
+        : this(value, displayName, String.Empty)
+    {
+    }
 
     public SelectOption(object? value, string displayName, string translationId)
     {

--- a/Enigmatry.Entry.CodeGeneration.Configuration/Form/Controls/Select/SelectOptionsBuilder.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration/Form/Controls/Select/SelectOptionsBuilder.cs
@@ -22,12 +22,12 @@ public class SelectOptionsBuilder
         return this;
     }
 
-    public SelectOptionsBuilder WithFixedValues<T>() where T : Enum
+    public SelectOptionsBuilder WithFixedValues<T>(bool shouldGenerateTranslationKeys = true) where T : Enum
     {
         _fixedValues = Enum
             .GetValues(typeof(T))
             .Cast<T>()
-            .Select(x => new SelectOption(Convert.ToInt32(x), GetDisplayName<T>(x.ToString()), GetTranslationId(x)))
+            .Select(@enum => GetSelectOption(@enum, shouldGenerateTranslationKeys))
             .ToList();
         return this;
     }
@@ -80,6 +80,13 @@ public class SelectOptionsBuilder
             EmptyOption = _emptyOption,
             SelectAllOption = _selectAllOption
         };
+    }
+
+    private SelectOption GetSelectOption<T>(T x, bool shouldGenerateTranslationKeys) where T : Enum
+    {
+        return shouldGenerateTranslationKeys
+            ? new SelectOption(Convert.ToInt32(x), GetDisplayName<T>(x.ToString()), GetTranslationId(x))
+            : new SelectOption(Convert.ToInt32(x), GetDisplayName<T>(x.ToString()));
     }
 
     private string GetDisplayName<T>(string value) where T : Enum

--- a/Enigmatry.Entry.CodeGeneration.Configuration/I18NString.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration/I18NString.cs
@@ -14,7 +14,5 @@ public class I18NString
         Value = value;
     }
 
-    public bool HasContent() => Value.HasContent();
-
     public override string ToString() => Value;
 }

--- a/Enigmatry.Entry.CodeGeneration.Configuration/I18NString.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration/I18NString.cs
@@ -4,7 +4,7 @@ namespace Enigmatry.Entry.CodeGeneration.Configuration;
 
 public class I18NString
 {
-    public static readonly I18NString Empty = new I18NString(String.Empty, String.Empty);
+    public static readonly I18NString Empty = new(String.Empty, String.Empty);
     public string Key { get; }
     public string Value { get; }
 

--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-edit-generated.component.ts.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-edit-generated.component.ts.txt
@@ -48,7 +48,7 @@ export class MockEditGeneratedComponent implements OnInit, OnDestroy {
 
                 @Input() formStatusOptions: any[] = [{ value: null, displayName: $localize `:@@empty-option.none:None` }, { value: 0, displayName: $localize `:@@enum.enum-mock.first:First` }, { value: 1, displayName: $localize `:@@enum.enum-mock.second:Second` }, { value: 2, displayName: $localize `:@@enum.enum-mock.third:Third` }];
                 @Input() formStatusOptionsConfiguration: SelectConfiguration = { valueProperty: 'value', labelProperty: 'displayName', sortProperty: 'displayName' };
-                @Input() mockRadioOptions: any[] = [{ value: 0, displayName: $localize `:@@enum.enum-mock.first:First` }, { value: 1, displayName: $localize `:@@enum.enum-mock.second:Second` }, { value: 2, displayName: $localize `:@@enum.enum-mock.third:Third` }];
+                @Input() mockRadioOptions: any[] = [{ value: 0, displayName: 'First' }, { value: 1, displayName: 'Second' }, { value: 2, displayName: 'Third' }];
                 @Input() mockRadioOptionsConfiguration: SelectConfiguration = { valueProperty: 'value', labelProperty: 'displayName', sortProperty: '' };
                 @Input() mockMultiCheckboxOptions: any[] = [{ value: 0, displayName: $localize `:@@enum.enum-mock.first:First` }, { value: 1, displayName: $localize `:@@enum.enum-mock.second:Second` }, { value: 2, displayName: $localize `:@@enum.enum-mock.third:Third` }];
                 @Input() mockMultiCheckboxOptionsConfiguration: SelectConfiguration = { valueProperty: 'value', labelProperty: 'displayName', sortProperty: '' };

--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/Mocks/FormMockConfiguration.cs
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/Mocks/FormMockConfiguration.cs
@@ -79,7 +79,7 @@ public class FormMockConfiguration : IFormComponentConfiguration<FormMock>
         formGroup
             .RadioGroupFormControl(x => x.MockRadio)
             .WithLabel("Radio")
-            .WithOptions(options => options.WithFixedValues<EnumMock>());
+            .WithOptions(options => options.WithFixedValues<EnumMock>(false));
 
         formGroup
             .MultiCheckboxFormControl(x => x.MockMultiCheckbox)

--- a/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.Form.Component.cshtml
+++ b/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.Form.Component.cshtml
@@ -1,5 +1,6 @@
 ﻿@using Enigmatry.Entry.CodeGeneration
 @using Enigmatry.Entry.CodeGeneration.Angular
+@using Enigmatry.Entry.CodeGeneration.Configuration
 @using Enigmatry.Entry.CodeGeneration.Configuration.Form.Controls
 @using Enigmatry.Entry.CodeGeneration.Configuration.Form.Controls.Array
 @using Enigmatry.Entry.CodeGeneration.Templates.HtmlHelperExtensions.Angular
@@ -102,7 +103,7 @@ import { map, throttleTime } from 'rxjs/operators';
         }
             @:@Html.AddAttributes(control)
             @:hidden: !@control.Visible.ToString().ToLower(),
-        @if (control.Tooltip.HasContent())
+        @if (control.Tooltip.Value.HasContent())
         {
             @:tooltipText: @Html.Localize(control.Tooltip, Options.EnableI18N),
         }

--- a/Enigmatry.Entry.CodeGeneration/Templates/HtmlHelperExtensions/Angular/AngularLocalization.cs
+++ b/Enigmatry.Entry.CodeGeneration/Templates/HtmlHelperExtensions/Angular/AngularLocalization.cs
@@ -7,14 +7,13 @@ namespace Enigmatry.Entry.CodeGeneration.Templates.HtmlHelperExtensions.Angular;
 
 public static class AngularLocalization
 {
-    public static IHtmlContent Localize(this IHtmlHelper html, string key, string text, bool enableI18N)
-    {
-        return enableI18N && text.HasContent() ? html.Raw(Localize(key, text)) : html.Raw($"'{text}'");
-    }
-
     public static IHtmlContent Localize(this IHtmlHelper html, I18NString? text, bool enableI18N)
     {
-        return text != null && enableI18N && text.HasContent() ? html.Raw(Localize(text.Key, text.Value)) : html.Raw($"'{text?.Value ?? String.Empty}'");
+        if (enableI18N && text != null && text.Key.HasContent() && text.Value.HasContent())
+        {
+            return html.Raw(Localize(text.Key, text.Value));
+        }
+        return html.Raw($"'{text?.Value ?? String.Empty}'");
     }
 
     public static string Localize(string key, string value)


### PR DESCRIPTION
When i18n is enabled it's not possible to define fixed values for a select without having to provide a translation id for each value.