### PR TITLE
BP-588: OrderBy(OrderByType.Configuration) option not working for Table component.

### DIFF
--- a/Enigmatry.Entry.CodeGeneration.Configuration.Tests/List/ColumnDefinitionBuilderFixture.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration.Tests/List/ColumnDefinitionBuilderFixture.cs
@@ -3,7 +3,7 @@ using Enigmatry.Entry.CodeGeneration.Configuration.List.Model;
 using FluentAssertions;
 using NUnit.Framework;
 
-namespace Enigmatry.Entry.CodeGeneration.Configuration.Tests.List.Model;
+namespace Enigmatry.Entry.CodeGeneration.Configuration.Tests.List;
 
 [Category("unit")]
 public class ColumnDefinitionBuilderFixture

--- a/Enigmatry.Entry.CodeGeneration.Configuration.Tests/List/ListComponentConfigurationFixture.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration.Tests/List/ListComponentConfigurationFixture.cs
@@ -38,7 +38,7 @@ public class ListComponentConfigurationFixture
         componentModel.Should().NotBeNull();
         componentModel.Columns.Count.Should().Be(5);
 
-        // Property order: Id, Title, StarDate, EndDate, Budget
+        // Property order: Id, Title, StartDate, EndDate, Budget
         componentModel.ComponentInfo.OrderByType.Should().Be(OrderByType.Model);
         componentModel.Columns.ElementAt(0).Property.ToLower().Should().Be(nameof(Project.Id).ToLower());
         componentModel.Columns.ElementAt(1).Property.ToLower().Should().Be(nameof(Project.Title).ToLower());

--- a/Enigmatry.Entry.CodeGeneration.Configuration.Tests/List/ListComponentConfigurationFixture.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration.Tests/List/ListComponentConfigurationFixture.cs
@@ -61,7 +61,7 @@ public class ListComponentConfigurationFixture
         componentModel.Should().NotBeNull();
         componentModel.Columns.Count.Should().Be(5);
 
-        // Configuration order: Id, Title, Budget, StarDate, EndDate
+        // Configuration order: Id, Title, Budget, StartDate, EndDate
         componentModel.ComponentInfo.OrderByType.Should().Be(OrderByType.Configuration);
         componentModel.Columns.ElementAt(0).Property.ToLower().Should().Be(nameof(Project.Id).ToLower());
         componentModel.Columns.ElementAt(1).Property.ToLower().Should().Be(nameof(Project.Title).ToLower());

--- a/Enigmatry.Entry.CodeGeneration.Configuration.Tests/List/ListComponentConfigurationFixture.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration.Tests/List/ListComponentConfigurationFixture.cs
@@ -11,7 +11,7 @@ public class ListComponentConfigurationFixture
     [Test]
     public void TestListComponentConfiguration()
     {
-        var configuration = new ConfigurationP();
+        var configuration = new Configuration1();
         var builder = new ListComponentBuilder<Project>();
 
         configuration.Configure(builder);
@@ -27,7 +27,7 @@ public class ListComponentConfigurationFixture
     [Test]
     public void TestOrderByModel()
     {
-        var configuration = new ConfigurationP();
+        var configuration = new Configuration1();
         var builder = new ListComponentBuilder<Project>();
 
         builder.Component().OrderBy(OrderByType.Model);
@@ -50,7 +50,7 @@ public class ListComponentConfigurationFixture
     [Test]
     public void TestOrderByConfiguration()
     {
-        var configuration = new ConfigurationP();
+        var configuration = new Configuration1();
         var builder = new ListComponentBuilder<Project>();
 
         builder.Component().OrderBy(OrderByType.Configuration);
@@ -73,7 +73,7 @@ public class ListComponentConfigurationFixture
     [Test]
     public void TestIncludeUnconfiguredPropertiesIsTrueWhenNotConfigured()
     {
-        var configuration = new ConfigurationP();
+        var configuration = new Configuration1();
         var builder = new ListComponentBuilder<Project>();
 
         configuration.Configure(builder);
@@ -87,7 +87,7 @@ public class ListComponentConfigurationFixture
     [Test]
     public void TestExcludeUnconfiguredProperties()
     {
-        var configuration = new ConfigurationP();
+        var configuration = new Configuration1();
         var builder = new ListComponentBuilder<Project>();
 
         builder.Component().IncludeUnconfiguredProperties(false);
@@ -106,7 +106,7 @@ public class ListComponentConfigurationFixture
     [Test]
     public void TestDefaultPropertyFormatterForDates()
     {
-        var configuration = new ConfigurationP();
+        var configuration = new Configuration1();
         var builder = new ListComponentBuilder<Project>();
 
         configuration.Configure(builder);
@@ -126,7 +126,7 @@ public class ListComponentConfigurationFixture
         public decimal Budget { get; set; }
     }
 
-    internal class ConfigurationP : IListComponentConfiguration<Project>
+    internal class Configuration1 : IListComponentConfiguration<Project>
     {
         public void Configure(ListComponentBuilder<Project> builder)
         {

--- a/Enigmatry.Entry.CodeGeneration.lutconfig
+++ b/Enigmatry.Entry.CodeGeneration.lutconfig
@@ -1,0 +1,6 @@
+<LUTConfig Version="1.0">
+  <Repository />
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>true</ParallelTestRuns>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>


### PR DESCRIPTION
Fixes:
- BP-588: OrderBy(OrderByType.Configuration) option not working for Table component
When set to sort by Configuration, it still orders the table columns in order they are defined in model.
- BP-576: IncludeUnconfiguredProperties option not working for Table component
When set to false it does not excludes the properties