### PR TITLE
BP-828: FormControl floatLabel contains options that are no longer supported by angular material.

### DIFF
--- a/Enigmatry.Entry.CodeGeneration.Configuration/Form/Controls/FormControlFloatLabel.cs
+++ b/Enigmatry.Entry.CodeGeneration.Configuration/Form/Controls/FormControlFloatLabel.cs
@@ -4,8 +4,8 @@ namespace Enigmatry.Entry.CodeGeneration.Configuration.Form.Controls;
 
 public enum FormControlFloatLabel
 {
-    [Description("never")]
-    Never = 0,
+    [Description("auto")]
+    Auto = 0,
     [Description("always")]
     Always = 1
 }

--- a/Enigmatry.Entry.CodeGeneration/Templates/HtmlHelperExtensions/Angular/AngularMaterialHtmlHelperExtensions.cs
+++ b/Enigmatry.Entry.CodeGeneration/Templates/HtmlHelperExtensions/Angular/AngularMaterialHtmlHelperExtensions.cs
@@ -14,18 +14,18 @@ public static class AngularMaterialHtmlHelperExtensions
             return html.Raw("");
         }
 
-        var appearanceValue = EnumExtensions.GetDescription(appearance.Value);
+        var appearanceValue = appearance.Value.GetDescription();
         return html.Raw($"appearance: '{appearanceValue}',\r\n");
     }
 
-    public static IHtmlContent FloatLabel(this IHtmlHelper html, FormControlFloatLabel? appearance)
+    public static IHtmlContent FloatLabel(this IHtmlHelper html, FormControlFloatLabel? floatLabel)
     {
-        if (!appearance.HasValue)
+        if (!floatLabel.HasValue)
         {
             return html.Raw("");
         }
 
-        var floatLabelValue = EnumExtensions.GetDescription(appearance.Value);
+        var floatLabelValue = floatLabel.Value.GetDescription();
         return html.Raw($"floatLabel: '{floatLabelValue}',\r\n");
     }
 }


### PR DESCRIPTION
The option can be either set to `always` or `auto`