### PR TITLE
ignore ts rules in generated code

### DIFF
--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-edit-generated.component.ts.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-edit-generated.component.ts.txt
@@ -7,6 +7,9 @@
 // </auto-generated>
 // ------------------------------------------------------------------------------;
 /* eslint-disable */
+// @ts-nocheck
+// @ts-ignore
+// @ts-expect-error
 import { Component, EventEmitter, Inject, Input, LOCALE_ID, OnInit, OnDestroy, Optional, Output, TemplateRef } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';

--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-list-generated.component.ts.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-list-generated.component.ts.txt
@@ -7,6 +7,9 @@
 // </auto-generated>
 // ------------------------------------------------------------------------------;
 /* eslint-disable */
+// @ts-nocheck
+// @ts-ignore
+// @ts-expect-error
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';
 import { PagedData, SortDirection, CellTemplate, ContextMenuItem, RowContextMenuFormatter, RowClassFormatter, RowSelectionFormatter, ColumnDef, PageEvent, SortEvent } from '@enigmatry/entry-components/table';
 

--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/test-generated.module.ts.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/test-generated.module.ts.txt
@@ -7,6 +7,9 @@
 // </auto-generated>
 // ------------------------------------------------------------------------------;
 /* eslint-disable */
+// @ts-nocheck
+// @ts-ignore
+// @ts-expect-error
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from 'src/app/shared/shared.module';

--- a/Enigmatry.Entry.CodeGeneration/Rendering/DisclaimerTemplateAppender.cs
+++ b/Enigmatry.Entry.CodeGeneration/Rendering/DisclaimerTemplateAppender.cs
@@ -16,6 +16,9 @@ public class DisclaimerTemplateAppender : ITemplateWriterAppender
 // </auto-generated>
 // ------------------------------------------------------------------------------;
 /* eslint-disable */
+// @ts-nocheck
+// @ts-ignore
+// @ts-expect-error
 ";
 
     public bool AppendAtStart(string path) => Path.GetExtension(path) == ".ts";


### PR DESCRIPTION
In order to enable stricter rules in tsconfig, as shown below, we need to disable those ts checks in generated code

"compilerOptions": {
"noUnusedLocals": true,
"noUnusedParameters": true,