### PR TITLE
Make RowContextMenuFormatter generic in list component template

### DIFF
--- a/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-list-generated.component.ts.txt
+++ b/Enigmatry.Entry.CodeGeneration.Tests/Angular/FilesToBeGenerated/mock-list-generated.component.ts.txt
@@ -51,7 +51,7 @@ export class MockListGeneratedComponent implements OnInit {
         { id: 'edit', name: $localize `:@@:Edit` },
         { id: 'delete', name: $localize `:@@:Delete` }
     ];
-  @Input() rowContextMenuFormatter: RowContextMenuFormatter;
+  @Input() rowContextMenuFormatter: RowContextMenuFormatter<ListMockItem>;
   
   @Input() rowFocusVisible: boolean;
   @Input() rowClassFormatter: RowClassFormatter;

--- a/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.List.Component.cshtml
+++ b/Enigmatry.Entry.CodeGeneration/Templates/Angular/Material/Angular.List.Component.cshtml
@@ -43,7 +43,7 @@ export class @Model.AngularComponentName() implements OnInit {
 
   @@Input() showContextMenu = @Model.Row.ShowContextMenu.ToString().ToLower();
   @@Input() contextMenuItems: ContextMenuItem[] = @Html.CreateContextMenuItems(Model.Row.ContextMenuItems, Options.EnableI18N);
-  @@Input() rowContextMenuFormatter: RowContextMenuFormatter;
+  @@Input() rowContextMenuFormatter: RowContextMenuFormatter@(Html.Raw($"<{Model.ComponentInfo.ModelType}>"));
   
   @@Input() rowFocusVisible: boolean;
   @@Input() rowClassFormatter: RowClassFormatter;


### PR DESCRIPTION
PR [https://github.com/enigmatry/entry-angular-building-blocks/pull/280](url) made RowContextMenuFormatter generic in the entry building blocks. 
The Angular.List.Component.cshtml template now generates a generic RowContextMenuFormatter<T> with the actual model type (e.g. ListMockItem) instead of a plain untyped RowContextMenuFormatter